### PR TITLE
Update package.json to remove default description

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "whirlpool-gui",
   "productName": "whirlpool-gui",
   "version": "0.6.4",
-  "description": "Electron application boilerplate based on React, React Router, Webpack, React Hot Loader for rapid application development",
+  "description": "Desktop GUI for Whirlpool by Samourai-Wallet",
   "scripts": {
     "build": "concurrently \"yarn build-main\" \"yarn build-renderer\"",
     "build-dll": "cross-env NODE_ENV=development webpack --config ./configs/webpack.config.renderer.dev.dll.babel.js --colors",


### PR DESCRIPTION
The description in `package.json` is used by electron-builder to create the description for the `/usr/share/applications/whirlpool.desktop` file. This is the file that DEs and other application browsers use to display information about the program. This commit changes the default description to one that is more informative.