### PR TITLE
Minor tweaks to form labels on ConfigPage.

### DIFF
--- a/app/containers/ConfigPage.js
+++ b/app/containers/ConfigPage.js
@@ -185,7 +185,7 @@ export default class ConfigPage extends Component<Props> {
                       const myValue = parseInt(e.target.value)
                       myThis.onChangeCliConfig(cliConfig => cliConfig.mix.clientDelay = myValue)
                     }} defaultValue={cliConfig.mix.clientDelay} id="clientDelay"/>
-                    <label className='col-form-label col-sm-11'>Delay between each client connection</label>
+                    <label className='col-form-label col-sm-11'>Delay (in seconds) between each client connection</label>
                   </div>
                 </div>
               </div>
@@ -198,7 +198,7 @@ export default class ConfigPage extends Component<Props> {
                       const myValue = parseInt(e.target.value)
                       myThis.onChangeCliConfig(cliConfig => cliConfig.mix.tx0MaxOutputs = myValue)
                     }} defaultValue={cliConfig.mix.tx0MaxOutputs} id="tx0MaxOutputs"/>
-                    <label className='col-form-label col-sm-11'>Max premixs per TX0 (0 = no limit)</label>
+                    <label className='col-form-label col-sm-11'>Max premixes per TX0 (0 = no limit)</label>
                   </div>
                 </div>
               </div>
@@ -211,6 +211,7 @@ export default class ConfigPage extends Component<Props> {
                       const myValue = e.target.value
                       myThis.onChangeCliConfig(cliConfig => cliConfig.scode = myValue)
                     }} defaultValue={cliConfig.scode} id="scode"/>
+                    <label className='col-form-label col-sm-11'>A Samourai Discount Code for reduced-cost mixing.</label>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
I wasn't exactly sure what units the delay was specified in until going through the [Whirlpool guides](https://github.com/Samourai-Wallet/samourai-wallet-android/blob/develop/Guides/Whirlpool.md).

Figured it'd be useful to list -- and I tweaked a few other labels while I was there 🙂.